### PR TITLE
Replace JS alerts with message overlay

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <app-cargando-overlay></app-cargando-overlay>
+<app-mensaje-overlay></app-mensaje-overlay>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import { ApiserviceIndapService }      from './services/apis/apiservice-indap.se
 import { LoadingService }              from './services/serviceui/loading.service';
 import { LoggerService }               from './services/logger/logger.service';
 import { CargandoOverlayComponent }    from './shared/cargando-overlay.component';
+import { MensajeOverlayComponent }     from './shared/mensaje-overlay.component';
 
 export interface PerfilDTO {
   codigo: string;
@@ -19,7 +20,13 @@ export interface PerfilDTO {
 @Component({
   selector   : 'app-root',
   standalone : true,
-  imports    : [CommonModule, RouterModule, HttpClientModule, CargandoOverlayComponent],
+  imports    : [
+    CommonModule,
+    RouterModule,
+    HttpClientModule,
+    CargandoOverlayComponent,
+    MensajeOverlayComponent
+  ],
   templateUrl: './app.component.html',
   styleUrls  : ['./app.component.css']
 })

--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -8,6 +8,7 @@ import { inject } from '@angular/core';
 import {FichaselecionadaService} from '../../services/session/fichaselecionada.service';
 import {ApiserviceIndapService} from '../../services/apis/apiservice-indap.service';
 import {SesionAdminService} from '../../services/session/sesionadmin.service';
+import { MensajeOverlayService } from '../../services/serviceui/mensaje-overlay.service';
 import {saveAs} from 'file-saver';
 
 interface DocTabla {
@@ -49,7 +50,8 @@ export class RevisionfichaComponent implements OnInit {
 
   constructor(
     private fichaSrv : FichaselecionadaService,
-    private api      : ApiserviceIndapService
+    private api      : ApiserviceIndapService,
+    private msg      : MensajeOverlayService
   ) {
 
     console.log('[Revisionficha] constructor → session =', this.session);
@@ -75,7 +77,10 @@ export class RevisionfichaComponent implements OnInit {
     /* 2️⃣  User info desde el JWT */
     const userData = this.session.getTokenPayload()?.data;
     if (!userData) {
-      alert('La sesión ha expirado. Por favor vuelve a iniciar sesión.');
+      this.msg.show('La sesión ha expirado. Serás redirigido en 5 segundos.');
+      setTimeout(() => {
+        window.location.href = 'https://sistemas.indap.cl';
+      }, 5000);
       return;
     }
 
@@ -143,7 +148,7 @@ export class RevisionfichaComponent implements OnInit {
 
   guardar(doc: DocTabla) {
     if (!this.datosValidos(doc)) {
-      alert('Debes ingresar observación y fecha de vigencia.');
+      this.msg.show('Debes ingresar observación y fecha de vigencia.');
       return;
     }
 
@@ -164,7 +169,7 @@ export class RevisionfichaComponent implements OnInit {
 
   rechazarRevision() {
     if (!this.observacionDecision.trim()) {
-      alert('Por favor ingresa una observación para el rechazo.');
+      this.msg.show('Por favor ingresa una observación para el rechazo.');
       return;
     }
 
@@ -177,12 +182,12 @@ export class RevisionfichaComponent implements OnInit {
       )
       .subscribe({
         next: (res) => {
-          alert(`Ficha rechazada: ${res.estado}`);
+          this.msg.show(`Ficha rechazada: ${res.estado}`);
           // aquí podrías refrescar el listado, cerrar diálogo, etc.
         },
         error: (err) => {
           console.error(err);
-          alert('Error al rechazar la ficha');
+          this.msg.show('Error al rechazar la ficha');
         }
       });
   }
@@ -205,12 +210,12 @@ export class RevisionfichaComponent implements OnInit {
     )
       .subscribe({
         next: (res) => {
-          alert(`Ficha aprobada: ${res.estado}`);
+          this.msg.show(`Ficha aprobada: ${res.estado}`);
           // acciones posteriores...
         },
         error: (err) => {
           console.error(err);
-          alert('Error al aprobar la ficha');
+          this.msg.show('Error al aprobar la ficha');
         }
       });
   }
@@ -256,7 +261,7 @@ export class RevisionfichaComponent implements OnInit {
       },
       error: (err) => {
         console.error(err);
-        alert('No se pudo generar el certificado PDF');
+        this.msg.show('No se pudo generar el certificado PDF');
       }
     });
   }

--- a/src/app/services/serviceui/mensaje-overlay.service.spec.ts
+++ b/src/app/services/serviceui/mensaje-overlay.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { MensajeOverlayService } from './mensaje-overlay.service';
+
+describe('MensajeOverlayService', () => {
+  let service: MensajeOverlayService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MensajeOverlayService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/serviceui/mensaje-overlay.service.ts
+++ b/src/app/services/serviceui/mensaje-overlay.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MensajeOverlayService {
+  private msgSubject = new BehaviorSubject<string | null>(null);
+  message$ = this.msgSubject.asObservable();
+
+  show(msg: string, durationMs = 5000) {
+    this.msgSubject.next(msg);
+    if (durationMs > 0) {
+      setTimeout(() => this.hide(), durationMs);
+    }
+  }
+
+  hide() {
+    this.msgSubject.next(null);
+  }
+}

--- a/src/app/shared/mensaje-overlay.component.css
+++ b/src/app/shared/mensaje-overlay.component.css
@@ -1,0 +1,21 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.mensaje {
+  background: var(--color_blanco);
+  color: var(--color_text);
+  border: 2px solid var(--color_link_dark);
+  padding: 1.5rem 2rem;
+  border-radius: 4px;
+  max-width: 90%;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+}

--- a/src/app/shared/mensaje-overlay.component.ts
+++ b/src/app/shared/mensaje-overlay.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MensajeOverlayService } from '../services/serviceui/mensaje-overlay.service';
+
+@Component({
+  selector: 'app-mensaje-overlay',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="msgSvc.message$ | async as msg" class="overlay">
+      <div class="mensaje">{{ msg }}</div>
+    </div>
+  `,
+  styleUrls: ['./mensaje-overlay.component.css']
+})
+export class MensajeOverlayComponent {
+  constructor(public msgSvc: MensajeOverlayService) {}
+}


### PR DESCRIPTION
## Summary
- add `MensajeOverlayService` for showing overlay messages
- create `MensajeOverlayComponent`
- embed new overlay component in `AppComponent`
- swap `alert()` calls in `RevisionfichaComponent` for overlay messages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ecc9c53083218a29ca50b3fac448