### PR TITLE
Improve overlay message styling

### DIFF
--- a/src/app/shared/mensaje-overlay.component.css
+++ b/src/app/shared/mensaje-overlay.component.css
@@ -10,12 +10,14 @@
 }
 
 .mensaje {
-  background: var(--color_blanco);
-  color: var(--color_text);
-  border: 2px solid var(--color_link_dark);
+  /* Estilo inspirado en el diseño del Gobierno de Chile */
+  background: var(--color_gob_azul);
+  color: var(--color_blanco);
+  border-left: 6px solid var(--color_gob_rojo);
   padding: 1.5rem 2rem;
   border-radius: 4px;
   max-width: 90%;
   text-align: center;
-  box-shadow: 0 0 10px rgba(0,0,0,0.3);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  font-family: var(--font_sans);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -16,6 +16,10 @@
   --color_gris_claro: #F2F2F2;
   --color-celeste-tabla: #CFE1F3;
 
+  /* Colores institucionales Gobierno de Chile */
+  --color_gob_azul: #0033a0;
+  --color_gob_rojo: #c60c30;
+
   --color_exito: #4CAF50;
   --color_error: #FB3B3B;
 


### PR DESCRIPTION
## Summary
- add institutional color variables for Gobierno de Chile
- restyle overlay message component to match government look

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e1d28740832193a50fcf404888e9