### PR TITLE
Fix mixed content by using protocol-relative API URL

### DIFF
--- a/src/app/environments/environment.prod.ts
+++ b/src/app/environments/environment.prod.ts
@@ -1,6 +1,8 @@
 export const environment = {
   production: true,
-  baseurl: "https://rfp-backend.qa.k24.indap.cl",
+  // Usamos una URL relativa al protocolo para evitar problemas de
+  // "mixed content" si el backend redirecciona entre http y https
+  baseurl: "//rfp-backend.qa.k24.indap.cl",
   claveUnica: {
     clientId:  'cd40ad229df147389504190c71de61f5',
     clientSecret: '78ce7c028c9b4b629b7bc2b1b86fa199',


### PR DESCRIPTION
## Summary
- use protocol-relative API URL so requests match the page protocol

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473c28701c8321ac6fed61f0dab811