### PR TITLE
Update HTTPS interceptor

### DIFF
--- a/src/app/interceptors/force-https.interceptor.ts
+++ b/src/app/interceptors/force-https.interceptor.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
 
 /**
  * Interceptor que asegura que todas las solicitudes HTTP utilicen HTTPS.
@@ -8,7 +9,7 @@ import { Observable } from 'rxjs';
 @Injectable()
 export class ForceHttpsInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (req.url.startsWith('http://')) {
+    if (environment.production && req.url.startsWith('http://')) {
       const secureUrl = 'https://' + req.url.substring('http://'.length);
       const secureReq = req.clone({ url: secureUrl });
       return next.handle(secureReq);


### PR DESCRIPTION
## Summary
- enforce HTTPS only when `environment.production` is true

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_684758b8d3148321b16a39898ee70366