### PR TITLE
Fix header name display

### DIFF
--- a/src/app/components/headeradmin/headeradmin.component.ts
+++ b/src/app/components/headeradmin/headeradmin.component.ts
@@ -42,12 +42,13 @@ export class HeaderadminComponent implements OnInit {
 
     const data = this.sessionSrv.getUserData();
     if (data) {
-      const nomCompleto = data.nombre || `${data.nombres ?? ''} ${data.apellido_paterno ?? ''} ${data.apellido_materno ?? ''}`;
-      const nomCorto = nomCompleto.trim().split(/\s+/).slice(0, 2).join(' ');
+      const primerNombre = `${data.nombres ?? ''}`.trim().split(/\s+/)[0] ?? '';
+      const primerApellido = `${data.apellido_paterno ?? ''}`.trim().split(/\s+/)[0] ?? '';
+      const nomCortoRaw = `${primerNombre} ${primerApellido}`.trim();
       try {
-        this.nombreUsuario = decodeURIComponent(escape(nomCorto)).trim();
+        this.nombreUsuario = this.decodeHtml(nomCortoRaw);
       } catch {
-        this.nombreUsuario = nomCorto.trim();
+        this.nombreUsuario = nomCortoRaw;
       }
     }
   }
@@ -84,5 +85,11 @@ export class HeaderadminComponent implements OnInit {
     ['a11y-font-0','a11y-font-1','a11y-font-2']
       .forEach(c => this.renderer.removeClass(html, c));
     this.renderer.addClass(html, `a11y-font-${this.nivelFuente}`);
+  }
+
+  private decodeHtml(text: string): string {
+    const txt = this.doc.createElement('textarea');
+    txt.innerHTML = text;
+    return decodeURIComponent(escape(txt.value));
   }
 }


### PR DESCRIPTION
## Summary
- show first name and last name with accents properly in admin header
- decode HTML entities for user name display

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482ab4d2ac8321ae1cee8278b2fffd