### PR TITLE
Fix HTTPS enforcement in QA

### DIFF
--- a/src/app/components/datos-empresa/datos-empresa.component.ts
+++ b/src/app/components/datos-empresa/datos-empresa.component.ts
@@ -23,7 +23,7 @@ import {MenuadminComponent} from '../menuadmin/menuadmin.component';
 export class DatosEmpresaComponent implements OnInit  {
 
 
-  private baseUrl = environment.baseurl;
+  private baseUrl = '';
   empresaForm: FormGroup;
   documentos: any[] = [];
   fichaCorta: any = null;
@@ -50,6 +50,9 @@ export class DatosEmpresaComponent implements OnInit  {
   }
 
   ngOnInit(): void {
+
+    // Usar la URL base calculada por el servicio para evitar "mixed content"
+    this.baseUrl = this.apiService.getBaseUrl();
 
     this.fichaCorta = this.fichaSrv.fichaSeleccionadaValue;
     console.log('Ficha corta recibida:', this.fichaCorta);

--- a/src/app/interceptors/force-https.interceptor.ts
+++ b/src/app/interceptors/force-https.interceptor.ts
@@ -9,7 +9,8 @@ import { environment } from '../environments/environment';
 @Injectable()
 export class ForceHttpsInterceptor implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (environment.production && req.url.startsWith('http://')) {
+    const pageIsHttps = typeof window !== 'undefined' && window.location.protocol === 'https:';
+    if (pageIsHttps && req.url.startsWith('http://')) {
       const secureUrl = 'https://' + req.url.substring('http://'.length);
       const secureReq = req.clone({ url: secureUrl });
       return next.handle(secureReq);

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -35,6 +35,11 @@ export class ApiserviceIndapService {
     this.apiUrlLocation = `${this.baseurllocation}/location/`;
   }
 
+  /** Obtiene la URL base actual (ajustada a HTTPS si corresponde). */
+  getBaseUrl(): string {
+    return this.baseurl;
+  }
+
 
   getPerfilPorCodigo(codigo: number | string) {
     const url = `${this.baseurl.replace(/\/$/, '')}/persona-juridica/perfil/${codigo}`;


### PR DESCRIPTION
## Summary
- expose sanitized backend url via `ApiserviceIndapService`
- consume sanitized url in `DatosEmpresaComponent`
- force HTTPS for all requests when page is served with HTTPS

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684834f6bbf88321925e7507bc7ed8d5