### PR TITLE
Add warnings for empty or failed movement data

### DIFF
--- a/src/app/components/mis-movimientos/mis-movimientos.component.html
+++ b/src/app/components/mis-movimientos/mis-movimientos.component.html
@@ -1,7 +1,15 @@
 <div class="container mt-4">
   <h2>Mis Movimientos</h2>
 
-  <table class="table" *ngIf="movimientos.length; else sinDatos">
+  <div *ngIf="errorMsg" class="alert alert-danger" role="alert">
+    {{ errorMsg }}
+  </div>
+
+  <div *ngIf="warningMsg && !errorMsg" class="alert alert-warning" role="alert">
+    {{ warningMsg }}
+  </div>
+
+  <table class="table" *ngIf="movimientos.length">
     <thead>
       <tr>
         <th>Fecha</th>
@@ -19,8 +27,4 @@
       </tr>
     </tbody>
   </table>
-
-  <ng-template #sinDatos>
-    <p *ngIf="!cargando">No se encontraron movimientos.</p>
-  </ng-template>
 </div>

--- a/src/app/components/mis-movimientos/mis-movimientos.component.ts
+++ b/src/app/components/mis-movimientos/mis-movimientos.component.ts
@@ -15,6 +15,8 @@ import { FichaselecionadaService } from '../../services/session/fichaselecionada
 export class MisMovimientosComponent implements OnInit {
   movimientos: any[] = [];
   cargando = false;
+  errorMsg = '';
+  warningMsg = '';
 
   constructor(
     private api: ApiserviceIndapService,
@@ -27,9 +29,19 @@ export class MisMovimientosComponent implements OnInit {
     const rutBase = this.session.getRutBase();
     if (!rutBase) { return; }
     this.cargando = true;
+    this.errorMsg = '';
+    this.warningMsg = '';
     this.api.obtenerMovimientosPorRut(rutBase).subscribe({
-      next: data => { this.movimientos = data || []; },
-      error: err => console.error('Error obteniendo movimientos', err),
+      next: data => {
+        this.movimientos = data || [];
+        if (!this.movimientos.length) {
+          this.warningMsg = 'No se encontraron movimientos.';
+        }
+      },
+      error: err => {
+        console.error('Error obteniendo movimientos', err);
+        this.errorMsg = 'Ocurri\u00f3 un error al obtener los movimientos.';
+      },
       complete: () => { this.cargando = false; }
     });
   }


### PR DESCRIPTION
## Summary
- show yellow alert if there are no movement records
- show red alert if movement fetch fails

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6849ad1fed68832191a425ce0ef3bcf8