### PR TITLE
Show user session data on profile page

### DIFF
--- a/src/app/components/perfil/perfil.component.html
+++ b/src/app/components/perfil/perfil.component.html
@@ -4,11 +4,15 @@
     <div class="card-body" *ngIf="datos">
       <dl class="row">
         <dt class="col-sm-4">Nombre Completo</dt>
-        <dd class="col-sm-8">{{ datos.nombres }} {{ datos.apellido_paterno }} {{ datos.apellido_materno }}</dd>
+        <dd class="col-sm-8">{{ nombreCompleto }}</dd>
         <dt class="col-sm-4">RUT</dt>
         <dd class="col-sm-8">{{ datos.rut }}</dd>
+        <dt class="col-sm-4">Nick</dt>
+        <dd class="col-sm-8">{{ datos.nick }}</dd>
         <dt class="col-sm-4">Región</dt>
         <dd class="col-sm-8">{{ region }}</dd>
+        <dt class="col-sm-4">Perfil Activo</dt>
+        <dd class="col-sm-8">{{ perfilActual?.perfil }}</dd>
       </dl>
       <div *ngIf="esAdmin" class="alert alert-info mt-3">Usuario Administrador</div>
     </div>

--- a/src/app/components/perfil/perfil.component.ts
+++ b/src/app/components/perfil/perfil.component.ts
@@ -13,12 +13,36 @@ export class PerfilComponent implements OnInit {
   datos: any = null;
   region = '';
   esAdmin: boolean | null = null;
+  nombreCompleto = '';
+  perfilActual: { codigo: number; perfil: string } | null = null;
 
   constructor(private session: SesionAdminService) {}
 
   ngOnInit(): void {
-    this.datos   = this.session.getUserData();
-    this.region  = this.session.getRegionName() || '';
-    this.esAdmin = this.session.getUsuarioSistema();
+    this.datos        = this.session.getUserData();
+    this.region       = this.session.getRegionName() || '';
+    this.esAdmin      = this.session.getUsuarioSistema();
+    this.perfilActual = this.session.getPerfilActual();
+
+    if (this.datos) {
+      const decode = (t: string) => {
+        const txt = document.createElement('textarea');
+        txt.innerHTML = t;
+        return txt.value;
+      };
+
+      if (this.datos.nombre) {
+        this.nombreCompleto = decode(this.datos.nombre).trim();
+      } else {
+        const partes = [
+          this.datos.nombres,
+          this.datos.apellido_paterno,
+          this.datos.apellido_materno,
+        ]
+          .filter(Boolean)
+          .map((s: string) => decode(s));
+        this.nombreCompleto = partes.join(' ').trim();
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- display full name, nickname, region and active profile
- decode HTML entities in profile component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_684acf323b108321a96f70da6c7174ac