### PR TITLE
Improve revision ficha layout

### DIFF
--- a/src/app/components/revisionficha/revisionficha.component.html
+++ b/src/app/components/revisionficha/revisionficha.component.html
@@ -2,6 +2,7 @@
 <br><br>
 <div class="container mt-3">
   <h3>Revisión Jurídica</h3>
+  <hr>
   <p><strong>Ley 19862</strong></p>
   <p>
     La persona jurídica debe estar inscrita en el registro nacional de receptores de fondos públicos del Ministerio de Hacienda.
@@ -11,16 +12,29 @@
 
   <!-- Preguntas -->
   <div class="mb-3">
-    <p><strong>¿Está inscrito en Registro Ley 19862?</strong></p>
-    <input type="radio" name="registro19862" id="registro-si"> <label for="registro-si">Sí</label>
-    <input type="radio" name="registro19862" id="registro-no"> <label for="registro-no">No</label>
+    <label class="form-label fw-bold">¿Está inscrito en Registro Ley 19862?</label>
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="registro19862" id="registro-si">
+      <label class="form-check-label" for="registro-si">Sí</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="registro19862" id="registro-no">
+      <label class="form-check-label" for="registro-no">No</label>
+    </div>
   </div>
 
   <div class="mb-3">
-    <p><strong>¿Los datos del registro son correctos y actualizados?</strong></p>
-    <input type="radio" name="datosCorrectos" id="datos-si"> <label for="datos-si">Sí</label>
-    <input type="radio" name="datosCorrectos" id="datos-no"> <label for="datos-no">No</label>
+    <label class="form-label fw-bold">¿Los datos del registro son correctos y actualizados?</label>
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="datosCorrectos" id="datos-si">
+      <label class="form-check-label" for="datos-si">Sí</label>
+    </div>
+    <div class="form-check">
+      <input class="form-check-input" type="radio" name="datosCorrectos" id="datos-no">
+      <label class="form-check-label" for="datos-no">No</label>
+    </div>
   </div>
+  <hr>
 
   <!-- Subida de Certificado -->
 
@@ -50,9 +64,10 @@
     </button>
     <div class="mt-2" *ngIf="mensaje">{{ mensaje }}</div>
   </div>
+  <hr>
 
   <!-- Tabla de Datos y Documentos -->
-  <h5>Datos y documentos</h5>
+  <h3>Datos y documentos</h3>
   <p>Los documentos y datos asociados a la ficha deben ser correctos y estar vigentes.</p>
 
   <table class="table table-striped table-bordered text-center">
@@ -106,6 +121,7 @@
     </tr>
     </tbody>
   </table>
+  <hr>
 
   <!-- Observaciones -->
   <div class="mb-3">
@@ -119,8 +135,9 @@
       placeholder="Documento está fuera de vigencia">
       </textarea>
   </div>
+  <hr>
 
-  <h4 class="mt-4">Historial de la ficha</h4>
+  <h3 class="mt-4">Historial de la ficha</h3>
 
   <div *ngIf="historial.length === 0" class="alert alert-info">
     No existen eventos registrados para esta ficha.
@@ -147,32 +164,32 @@
     </tr>
     </tbody>
   </table>
+  <hr>
 
-
-  <div class="d-flex justify-content-between w-100"
+  <div class="d-flex justify-content-end gap-2"
        *ngIf="mostrarAcciones">
-    <button class="btn btn-success"
-            style="background-color:#28a745;border-color:#28a745;"
+    <button class="btn btn-secondary"
             (click)="aprobarRevision()">
-      <i class="fa fa-save"></i> Aprobar Revisión
+      Aprobar Revisión
     </button>
 
-    <button class="btn btn-danger"
+    <button class="btn btn-secondary"
             (click)="rechazarRevision()">
-      <i class="fa fa-save"></i> Rechazar Revisión
+      Rechazar Revisión
     </button>
   </div>
 
-
-  <button
-    class="btn btn-outline-primary me-2"
-    (click)="descargarCertificado()"
-  >
-    <i class="fa fa-file-pdf-o"></i>
-    Descargar certificado
-  </button>
+  <div class="d-flex justify-content-end mt-3">
+    <button class="btn btn-secondary"
+            (click)="descargarCertificado()"
+            [disabled]="!puedeDescargar">
+      <i class="fa fa-file-pdf-o"></i>
+      Descargar certificado
+    </button>
+  </div>
 
   <!-- Revisión Financiera -->
+  <hr>
   <h3 class="mt-4">Revisión Financiera</h3>
   <p>Pendiente.</p>
 </div>

--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -43,6 +43,7 @@ export class RevisionfichaComponent implements OnInit {
   subiendo   = false;
   mensaje    = '';
   mostrarAcciones = true;
+  puedeDescargar = false;
   idUsuario!: number;                     // ← ahora será el RUT sin DV
   registro1986Cargado = false;
 
@@ -128,7 +129,22 @@ export class RevisionfichaComponent implements OnInit {
     console.log('[Revisionficha] buscamos   :', buscadoNorm);
     console.log('[Revisionficha] en historial:', halladoEnHist);
 
+
     this.mostrarAcciones = !(estadoFicha.includes(buscadoNorm) || halladoEnHist);
+
+    const aprobadoFinanzas =
+      estadoFicha.includes('aprobado - finanzas') ||
+      this.historial.some(h =>
+        this.normalizar(h.estado).includes('aprobado - finanzas')
+      );
+
+    const aprobadoJuridica =
+      estadoFicha.includes('aprobado - juridica') ||
+      this.historial.some(h =>
+        this.normalizar(h.estado).includes('aprobado - juridica')
+      );
+
+    this.puedeDescargar = aprobadoFinanzas && aprobadoJuridica;
 
 
 


### PR DESCRIPTION
## Summary
- style and space out questions about Registro Ley 19862
- add section separators and uniform headings
- adjust action buttons with Gobierno de Chile look
- enable certificate download only after both approvals

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503e8b7ae48321842b480126174d56