### PR TITLE
Configure prod logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ ng build
 
 This will compile your project and store the build artifacts in the `dist/` directory. By default, the production build optimizes your application for performance and speed.
 
+## Environment modes
+
+The application uses Angular's environment files to toggle between development and production. The `envName` property inside `environment` indicates the current mode. When running in development the console output is verbose so you can follow each step of the application. For production builds all log messages are automatically suppressed.
+
 ## Running unit tests
 
 To execute unit tests with the [Karma](https://karma-runner.github.io) test runner, use the following command:

--- a/src/app/environments/environment.prod.ts
+++ b/src/app/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  envName: 'production',
   // Usamos una URL relativa al protocolo para evitar problemas de
   // "mixed content" si el backend redirecciona entre http y https
   baseurl: "https://rfp-backend.qa.k24.indap.cl",

--- a/src/app/environments/environment.ts
+++ b/src/app/environments/environment.ts
@@ -1,6 +1,7 @@
 
 export const environment = {
   production: false,
+  envName: 'development',
   baseurlocal: "http://localhost:4300/",
   baseurl: "http://localhost:8000",
   claveUnica: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,18 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { enableProdMode } from '@angular/core';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import { environment } from './app/environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+  console.log = () => {};
+  console.info = () => {};
+  console.debug = () => {};
+  console.warn = () => {};
+} else {
+  console.log(`[BOOT] Starting application in ${environment.envName} mode`);
+}
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- add `envName` property to environment files
- disable console logging when building for production
- document environment modes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506590c4308321a7b54a496be531e3