### PR TITLE
Add HTTP logging interceptor

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,6 +2,7 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, HTTP_INTERCEPTORS, withInterceptorsFromDi } from '@angular/common/http';
 import { ForceHttpsInterceptor } from './interceptors/force-https.interceptor';
+import { LoggingInterceptor } from './interceptors/logging.interceptor';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -9,6 +10,7 @@ export const appConfig: ApplicationConfig = {
     // Habilitamos los interceptores definidos en el DI para HttpClient
     provideHttpClient(withInterceptorsFromDi()),
     { provide: HTTP_INTERCEPTORS, useClass: ForceHttpsInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: LoggingInterceptor, multi: true },
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes)
   ]

--- a/src/app/interceptors/logging.interceptor.ts
+++ b/src/app/interceptors/logging.interceptor.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+import { LoggerService } from '../services/logger/logger.service';
+
+/**
+ * Interceptor that logs all outgoing HTTP requests and their responses.
+ */
+@Injectable()
+export class LoggingInterceptor implements HttpInterceptor {
+  constructor(private logger: LoggerService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const started = Date.now();
+    this.logger.info(`[HTTP] ${req.method} ${req.url}`);
+    return next.handle(req).pipe(
+      tap({
+        next: (event) => {
+          if (event instanceof HttpResponse) {
+            const elapsed = Date.now() - started;
+            this.logger.info(`[HTTP] ${req.method} ${req.url} \u2713 (${elapsed} ms)`);
+          }
+        },
+        error: (error: HttpErrorResponse) => {
+          const elapsed = Date.now() - started;
+          this.logger.error(`[HTTP] ${req.method} ${req.url} \u2717 (${elapsed} ms)`, error.message);
+        }
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- log all HTTP requests and responses via new `LoggingInterceptor`
- register the interceptor in `app.config.ts`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685066d5925883218f963d0cf4c6174f