### PR TITLE
Implement file download links

### DIFF
--- a/src/app/components/datos-empresa/datos-empresa.component.html
+++ b/src/app/components/datos-empresa/datos-empresa.component.html
@@ -74,8 +74,8 @@
     <!-- Recorremos 'documentos' con *ngFor -->
     <li *ngFor="let doc of documentos">
       <i class="fa fa-file"></i>
-      <!-- Mostramos la categoría (o el nombre) y creamos un link -->
-      <a [href]="buildFileUrl(doc.ruta_ftp)" target="_blank">
+      <!-- Mostramos la categoría (o el nombre) y ofrecemos descarga -->
+      <a href="" (click)="descargarDocumento(doc); $event.preventDefault()">
         {{ doc.categoria }} - {{ doc.nombre }}
       </a>
     </li>

--- a/src/app/components/datos-empresa/datos-empresa.component.ts
+++ b/src/app/components/datos-empresa/datos-empresa.component.ts
@@ -4,6 +4,8 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
+import { saveAs } from 'file-saver';
+
 import {ApiserviceIndapService} from '../../services/apis/apiservice-indap.service';
 import {FichaselecionadaService} from '../../services/session/fichaselecionada.service';
 import {environment} from '../../environments/environment';
@@ -97,5 +99,13 @@ export class DatosEmpresaComponent implements OnInit  {
     const base = this.baseUrl.replace(/\/$/, '');
     const cleanRuta = ruta.replace(/^\/+/, '');
     return `${base}/uploads/${cleanRuta}`;
+  }
+
+  descargarDocumento(doc: any) {
+    if (!doc?.ruta_ftp) { return; }
+    this.apiService.downloadDocumento(doc.ruta_ftp).subscribe(blob => {
+      const nombre = doc.nombre || 'archivo';
+      saveAs(blob, nombre);
+    });
   }
 }

--- a/src/app/components/revisionficha/revisionficha.component.html
+++ b/src/app/components/revisionficha/revisionficha.component.html
@@ -82,9 +82,12 @@
     </thead>
     <tbody>
     <tr *ngFor="let doc of documentos">
-      <!-- nombre documento: podrías enlazar descarga si lo deseas -->
+      <!-- nombre documento: permite descargar -->
       <td>
-        <a [routerLink]="[]" class="text-primary">{{ doc.nombre }}</a>
+        <a href="" class="text-primary"
+           (click)="descargarDocumento(doc); $event.preventDefault()">
+          {{ doc.nombre }}
+        </a>
       </td>
       <td>{{ doc.categoria || '-' }}</td>
 

--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -15,6 +15,7 @@ interface DocTabla {
   id_documento: number;
   nombre: string;
   categoria?: string;
+  ruta_ftp?: string;
   id_observacion_doc?: number;
   observacion?: string;
   fecha_vigencia?: string;
@@ -93,7 +94,8 @@ export class RevisionfichaComponent implements OnInit {
     this.documentos = (fichaCompleta.documentos || []).map((d: any) => ({
       id_documento: d.id_documento,
       nombre      : d.nombre,
-      categoria   : d.categoria
+      categoria   : d.categoria,
+      ruta_ftp    : d.ruta_ftp
     }));
 
     this.registro1986Cargado = this.documentos.some(
@@ -292,6 +294,14 @@ export class RevisionfichaComponent implements OnInit {
         this.mensaje = '❌ Error: ' + (err.error?.detail || 'no se pudo subir');
         this.subiendo = false;
       }
+    });
+  }
+
+  descargarDocumento(doc: DocTabla) {
+    if (!doc.ruta_ftp) { return; }
+    this.api.downloadDocumento(doc.ruta_ftp).subscribe(blob => {
+      const nombre = doc.nombre || 'archivo';
+      saveAs(blob, nombre);
     });
   }
 

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -212,6 +212,14 @@ export class ApiserviceIndapService {
     return this.http.get(url, { responseType: 'blob' });
   }
 
+  /** Descarga un archivo desde la ruta relativa entregada */
+  downloadDocumento(rutaRelativa: string) {
+    const base = this.baseurl.replace(/\/$/, '');
+    const cleanRuta = rutaRelativa.replace(/^\/+/, '');
+    const url = `${base}/uploads/${cleanRuta}`;
+    return this.http.get(url, { responseType: 'blob' });
+  }
+
   /** Obtiene los movimientos del usuario identificado por su rut base */
   obtenerMovimientosPorRut(rutBase: string): Observable<any[]> {
     return this.http.get<any[]>(`${this.pjuridica}movimientos/${rutBase}`);


### PR DESCRIPTION
## Summary
- add general document download helper in `ApiserviceIndapService`
- allow downloading documents from the datos-empresa component
- expose file paths for revisionficha documents and add download option

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850737aafa08321a5c22b5f87e7ebf5