### PR TITLE
Fix CORS issue when downloading docs

### DIFF
--- a/src/app/components/datos-empresa/datos-empresa.component.ts
+++ b/src/app/components/datos-empresa/datos-empresa.component.ts
@@ -5,7 +5,6 @@ import { RouterModule } from '@angular/router';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 
-import { saveAs } from 'file-saver';
 
 import {ApiserviceIndapService} from '../../services/apis/apiservice-indap.service';
 import {FichaselecionadaService} from '../../services/session/fichaselecionada.service';
@@ -104,9 +103,11 @@ export class DatosEmpresaComponent implements OnInit  {
 
   descargarDocumento(doc: any) {
     if (!doc?.ruta_ftp) { return; }
-    this.apiService.downloadDocumento(doc.ruta_ftp).subscribe(blob => {
-      const nombre = doc.nombre || 'archivo';
-      saveAs(blob, nombre);
-    });
+    const url = this.buildFileUrl(doc.ruta_ftp);
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.click();
   }
 }


### PR DESCRIPTION
## Summary
- handle file download with a simple link instead of HttpClient to avoid CORS issue

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685078dd6d0c8321b0dcb9cfacc88b3c