### PR TITLE
Fix direct file download

### DIFF
--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -311,10 +311,12 @@ export class RevisionfichaComponent implements OnInit {
 
   descargarDocumento(doc: DocTabla) {
     if (!doc.ruta_ftp) { return; }
-    this.api.downloadDocumento(doc.ruta_ftp).subscribe(blob => {
-      const nombre = doc.nombre || 'archivo';
-      saveAs(blob, nombre);
-    });
+    const url = this.buildFileUrl(doc.ruta_ftp);
+    const link = document.createElement('a');
+    link.href = url;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.click();
   }
 
   descargarCertificado() {


### PR DESCRIPTION
## Summary
- open document links directly instead of using the API

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685089950dc88321bd18a84eb702cae7