### PR TITLE
Add admin user management component

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -57,6 +57,12 @@ export const routes: Routes = [
           loadComponent: () =>
             import('./components/perfil/perfil.component').then(m => m.PerfilComponent),
         },
+        {
+          path: 'usuarios-sistema',
+          loadComponent: () =>
+            import('./components/usuarios-sistema/usuarios-sistema.component')
+              .then(m => m.UsuariosSistemaComponent),
+        },
 
 
     ],

--- a/src/app/components/headeradmin/headeradmin.component.html
+++ b/src/app/components/headeradmin/headeradmin.component.html
@@ -46,6 +46,8 @@
                 <a class="dropdown-item" [routerLink]="'/mis-movimientos'">Mis Movimientos</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" [routerLink]="'/perfil'">Mi Perfil</a>
+                <div *ngIf="esAdmin" class="dropdown-divider"></div>
+                <a *ngIf="esAdmin" class="dropdown-item" [routerLink]="'/usuarios-sistema'">Usuarios Sistema</a>
               </div>
             </div>
           </li>

--- a/src/app/components/headeradmin/headeradmin.component.ts
+++ b/src/app/components/headeradmin/headeradmin.component.ts
@@ -19,6 +19,7 @@ export class HeaderadminComponent implements OnInit {
 
   nombreUsuario = 'Usuario';
   pendingCount = 0;
+  esAdmin: boolean | null = null;
 
   private nivelFuente = 0;
   private readonly maxFuente = 2;
@@ -52,6 +53,8 @@ export class HeaderadminComponent implements OnInit {
         this.nombreUsuario = nomCortoRaw;
       }
     }
+
+    this.esAdmin = this.sessionSrv.getUsuarioSistema();
 
     this.fichaSrv.getFichasPendientes$().subscribe(n => {
       this.pendingCount = n;

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.css
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.css
@@ -1,0 +1,1 @@
+/* estilos básicos para la tabla de usuarios */

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.html
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.html
@@ -1,0 +1,68 @@
+<div class="container mt-4" *ngIf="esAdmin; else noAdmin">
+  <h2>Usuarios Sistema</h2>
+
+  <div *ngIf="errorMsg" class="alert alert-danger">{{ errorMsg }}</div>
+
+  <form (ngSubmit)="guardar()" class="mb-3">
+    <div class="form-row">
+      <div class="form-group col-md-2">
+        <input type="text" class="form-control" name="numero_region" [(ngModel)]="form.numero_region" placeholder="N° Región">
+      </div>
+      <div class="form-group col-md-2">
+        <input type="number" class="form-control" name="inregion" [(ngModel)]="form.inregion" placeholder="Id Región">
+      </div>
+      <div class="form-group col-md-2">
+        <input type="text" class="form-control" name="region" [(ngModel)]="form.region" placeholder="Región">
+      </div>
+      <div class="form-group col-md-3">
+        <input type="text" class="form-control" name="nombre" [(ngModel)]="form.nombre" placeholder="Nombre">
+      </div>
+      <div class="form-group col-md-3">
+        <input type="email" class="form-control" name="correo" [(ngModel)]="form.correo" placeholder="Correo">
+      </div>
+      <div class="form-group col-md-3">
+        <input type="text" class="form-control" name="cargo" [(ngModel)]="form.cargo" placeholder="Cargo">
+      </div>
+      <div class="form-group col-md-3">
+        <input type="text" class="form-control" name="unidad" [(ngModel)]="form.unidad" placeholder="Unidad">
+      </div>
+      <div class="form-group col-md-3">
+        <input type="text" class="form-control" name="rut" [(ngModel)]="form.rut" placeholder="RUT">
+      </div>
+    </div>
+    <button type="submit" class="btn btn-primary">{{ editId ? 'Actualizar' : 'Crear' }}</button>
+    <button *ngIf="editId" type="button" (click)="cancelar()" class="btn btn-secondary ml-2">Cancelar</button>
+  </form>
+
+  <table class="table table-striped" *ngIf="usuarios.length">
+    <thead>
+      <tr>
+        <th>Nombre</th>
+        <th>Correo</th>
+        <th>Región</th>
+        <th>Cargo</th>
+        <th>Unidad</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let u of usuarios">
+        <td>{{ u.nombre }}</td>
+        <td>{{ u.correo }}</td>
+        <td>{{ u.region }}</td>
+        <td>{{ u.cargo }}</td>
+        <td>{{ u.unidad }}</td>
+        <td>
+          <button class="btn btn-sm btn-link" (click)="editar(u)">Editar</button>
+          <button class="btn btn-sm btn-link text-danger" (click)="eliminar(u.id_usersistema)">Eliminar</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<ng-template #noAdmin>
+  <div class="container mt-4">
+    <div class="alert alert-danger">Acceso no autorizado.</div>
+  </div>
+</ng-template>

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { ApiserviceIndapService } from '../../services/apis/apiservice-indap.service';
+import { SesionAdminService } from '../../services/session/sesionadmin.service';
+
+@Component({
+  selector   : 'app-usuarios-sistema',
+  standalone : true,
+  imports    : [CommonModule, FormsModule, RouterModule],
+  templateUrl: './usuarios-sistema.component.html',
+  styleUrl   : './usuarios-sistema.component.css'
+})
+export class UsuariosSistemaComponent implements OnInit {
+  esAdmin = false;
+  usuarios: any[] = [];
+  editId: number | null = null;
+  errorMsg = '';
+
+  form: any = {
+    numero_region: '',
+    inregion: '',
+    region: '',
+    nombre: '',
+    correo: '',
+    cargo: '',
+    unidad: '',
+    rut: ''
+  };
+
+  constructor(
+    private api: ApiserviceIndapService,
+    private session: SesionAdminService
+  ) {}
+
+  ngOnInit(): void {
+    this.esAdmin = this.session.getUsuarioSistema() === true;
+    if (this.esAdmin) { this.cargarUsuarios(); }
+  }
+
+  cargarUsuarios(): void {
+    this.api.listarUsuariosSistema().subscribe({
+      next: data => { this.usuarios = data || []; },
+      error: err => {
+        console.error('Error cargando usuarios', err);
+        this.errorMsg = 'Error al obtener usuarios';
+      }
+    });
+  }
+
+  editar(u: any): void {
+    this.editId = u.id_usersistema;
+    this.form = { ...u };
+  }
+
+  cancelar(): void {
+    this.editId = null;
+    this.form = {
+      numero_region: '',
+      inregion: '',
+      region: '',
+      nombre: '',
+      correo: '',
+      cargo: '',
+      unidad: '',
+      rut: ''
+    };
+  }
+
+  guardar(): void {
+    const payload = { ...this.form };
+    if (this.editId) {
+      this.api.actualizarUsuarioSistema(this.editId, payload).subscribe({
+        next: () => { this.cancelar(); this.cargarUsuarios(); },
+        error: err => console.error('Error actualizando', err)
+      });
+    } else {
+      this.api.crearUsuarioSistema(payload).subscribe({
+        next: () => { this.cancelar(); this.cargarUsuarios(); },
+        error: err => console.error('Error creando', err)
+      });
+    }
+  }
+
+  eliminar(id: number): void {
+    if (!confirm('¿Eliminar usuario?')) { return; }
+    this.api.eliminarUsuarioSistema(id).subscribe({
+      next: () => this.cargarUsuarios(),
+      error: err => console.error('Error eliminando', err)
+    });
+  }
+}

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -243,4 +243,26 @@ export class ApiserviceIndapService {
     return this.http.post<any>(url, formData);
   }
 
+  /* ──────────────── Usersistema CRUD ──────────────── */
+
+  listarUsuariosSistema(skip = 0, limit = 100) {
+    return this.http.get<any[]>(`${this.apiRoot}/usersistema/?skip=${skip}&limit=${limit}`);
+  }
+
+  obtenerUsuarioSistema(id: number) {
+    return this.http.get<any>(`${this.apiRoot}/usersistema/${id}`);
+  }
+
+  crearUsuarioSistema(data: any) {
+    return this.http.post<any>(`${this.apiRoot}/usersistema/`, data);
+  }
+
+  actualizarUsuarioSistema(id: number, cambios: any) {
+    return this.http.put<any>(`${this.apiRoot}/usersistema/${id}`, cambios);
+  }
+
+  eliminarUsuarioSistema(id: number) {
+    return this.http.delete(`${this.apiRoot}/usersistema/${id}`);
+  }
+
 }


### PR DESCRIPTION
## Summary
- implement UsersSistema admin CRUD component
- expose users CRUD endpoints in `ApiserviceIndapService`
- add route `/usuarios-sistema`
- show new link in header only for admins

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685980022e7c83218e492260cae31621