### PR TITLE
Fix JWT token usage for usersistema service

### DIFF
--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
@@ -40,7 +40,12 @@ export class UsuariosSistemaComponent implements OnInit {
   }
 
   cargarUsuarios(): void {
-    this.api.listarUsuariosSistema().subscribe({
+    const token = this.session.getToken();
+    if (!token) {
+      this.errorMsg = 'Sesión expirada';
+      return;
+    }
+    this.api.listarUsuariosSistema(token).subscribe({
       next: data => { this.usuarios = data || []; },
       error: err => {
         console.error('Error cargando usuarios', err);
@@ -69,14 +74,19 @@ export class UsuariosSistemaComponent implements OnInit {
   }
 
   guardar(): void {
+    const token = this.session.getToken();
+    if (!token) {
+      this.errorMsg = 'Sesión expirada';
+      return;
+    }
     const payload = { ...this.form };
     if (this.editId) {
-      this.api.actualizarUsuarioSistema(this.editId, payload).subscribe({
+      this.api.actualizarUsuarioSistema(this.editId, payload, token).subscribe({
         next: () => { this.cancelar(); this.cargarUsuarios(); },
         error: err => console.error('Error actualizando', err)
       });
     } else {
-      this.api.crearUsuarioSistema(payload).subscribe({
+      this.api.crearUsuarioSistema(payload, token).subscribe({
         next: () => { this.cancelar(); this.cargarUsuarios(); },
         error: err => console.error('Error creando', err)
       });
@@ -85,7 +95,9 @@ export class UsuariosSistemaComponent implements OnInit {
 
   eliminar(id: number): void {
     if (!confirm('¿Eliminar usuario?')) { return; }
-    this.api.eliminarUsuarioSistema(id).subscribe({
+    const token = this.session.getToken();
+    if (!token) { return; }
+    this.api.eliminarUsuarioSistema(id, token).subscribe({
       next: () => this.cargarUsuarios(),
       error: err => console.error('Error eliminando', err)
     });

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -245,24 +245,47 @@ export class ApiserviceIndapService {
 
   /* ──────────────── Usersistema CRUD ──────────────── */
 
-  listarUsuariosSistema(skip = 0, limit = 100) {
-    return this.http.get<any[]>(`${this.apiRoot}/usersistema/?skip=${skip}&limit=${limit}`);
+  listarUsuariosSistema(token: string, skip = 0, limit = 100) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    return this.http.get<any[]>(
+      `${this.apiRoot}/usersistema/?skip=${skip}&limit=${limit}`,
+      { headers }
+    );
   }
 
-  obtenerUsuarioSistema(id: number) {
-    return this.http.get<any>(`${this.apiRoot}/usersistema/${id}`);
+  obtenerUsuarioSistema(id: number, token: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    return this.http.get<any>(`${this.apiRoot}/usersistema/${id}`, { headers });
   }
 
-  crearUsuarioSistema(data: any) {
-    return this.http.post<any>(`${this.apiRoot}/usersistema/`, data);
+  crearUsuarioSistema(data: any, token: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    return this.http.post<any>(`${this.apiRoot}/usersistema/`, data, { headers });
   }
 
-  actualizarUsuarioSistema(id: number, cambios: any) {
-    return this.http.put<any>(`${this.apiRoot}/usersistema/${id}`, cambios);
+  actualizarUsuarioSistema(id: number, cambios: any, token: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    return this.http.put<any>(`${this.apiRoot}/usersistema/${id}`, cambios, { headers });
   }
 
-  eliminarUsuarioSistema(id: number) {
-    return this.http.delete(`${this.apiRoot}/usersistema/${id}`);
+  eliminarUsuarioSistema(id: number, token: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    return this.http.delete(`${this.apiRoot}/usersistema/${id}`, { headers });
   }
 
 }


### PR DESCRIPTION
## Summary
- include JWT `token` header for all `usersistema` API calls
- pass the token from `UsuariosSistemaComponent` when calling CRUD actions

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6859acaeafdc832197625168e46aafd8