### PR TITLE
Add JWT interceptor and refine admin user UI

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,6 +3,7 @@ import { provideRouter } from '@angular/router';
 import { provideHttpClient, HTTP_INTERCEPTORS, withInterceptorsFromDi } from '@angular/common/http';
 import { ForceHttpsInterceptor } from './interceptors/force-https.interceptor';
 import { LoggingInterceptor } from './interceptors/logging.interceptor';
+import { JwtInterceptor } from './interceptors/jwt.interceptor';
 import { routes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
@@ -11,6 +12,7 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withInterceptorsFromDi()),
     { provide: HTTP_INTERCEPTORS, useClass: ForceHttpsInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: LoggingInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: JwtInterceptor, multi: true },
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes)
   ]

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.css
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.css
@@ -1,1 +1,8 @@
-/* estilos básicos para la tabla de usuarios */
+/* Estilos para Usuarios Sistema */
+.table {
+  font-size: 0.9rem;
+}
+
+.card form input {
+  font-size: 0.875rem;
+}

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.html
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.html
@@ -1,40 +1,44 @@
-<div class="container mt-4" *ngIf="esAdmin; else noAdmin">
-  <h2>Usuarios Sistema</h2>
+<div class="container my-4" *ngIf="esAdmin; else noAdmin">
+  <h2 class="mb-3">Usuarios Sistema</h2>
 
   <div *ngIf="errorMsg" class="alert alert-danger">{{ errorMsg }}</div>
 
-  <form (ngSubmit)="guardar()" class="mb-3">
-    <div class="form-row">
-      <div class="form-group col-md-2">
-        <input type="text" class="form-control" name="numero_region" [(ngModel)]="form.numero_region" placeholder="N° Región">
-      </div>
-      <div class="form-group col-md-2">
-        <input type="number" class="form-control" name="inregion" [(ngModel)]="form.inregion" placeholder="Id Región">
-      </div>
-      <div class="form-group col-md-2">
-        <input type="text" class="form-control" name="region" [(ngModel)]="form.region" placeholder="Región">
-      </div>
-      <div class="form-group col-md-3">
-        <input type="text" class="form-control" name="nombre" [(ngModel)]="form.nombre" placeholder="Nombre">
-      </div>
-      <div class="form-group col-md-3">
-        <input type="email" class="form-control" name="correo" [(ngModel)]="form.correo" placeholder="Correo">
-      </div>
-      <div class="form-group col-md-3">
-        <input type="text" class="form-control" name="cargo" [(ngModel)]="form.cargo" placeholder="Cargo">
-      </div>
-      <div class="form-group col-md-3">
-        <input type="text" class="form-control" name="unidad" [(ngModel)]="form.unidad" placeholder="Unidad">
-      </div>
-      <div class="form-group col-md-3">
-        <input type="text" class="form-control" name="rut" [(ngModel)]="form.rut" placeholder="RUT">
-      </div>
+  <div class="card mb-4">
+    <div class="card-body">
+      <form (ngSubmit)="guardar()" class="row g-3">
+        <div class="col-md-2">
+          <input type="text" class="form-control form-control-sm" name="numero_region" [(ngModel)]="form.numero_region" placeholder="N° Región">
+        </div>
+        <div class="col-md-2">
+          <input type="number" class="form-control form-control-sm" name="inregion" [(ngModel)]="form.inregion" placeholder="Id Región">
+        </div>
+        <div class="col-md-2">
+          <input type="text" class="form-control form-control-sm" name="region" [(ngModel)]="form.region" placeholder="Región">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm" name="nombre" [(ngModel)]="form.nombre" placeholder="Nombre">
+        </div>
+        <div class="col-md-3">
+          <input type="email" class="form-control form-control-sm" name="correo" [(ngModel)]="form.correo" placeholder="Correo">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm" name="cargo" [(ngModel)]="form.cargo" placeholder="Cargo">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm" name="unidad" [(ngModel)]="form.unidad" placeholder="Unidad">
+        </div>
+        <div class="col-md-3">
+          <input type="text" class="form-control form-control-sm" name="rut" [(ngModel)]="form.rut" placeholder="RUT">
+        </div>
+        <div class="col-12 text-end">
+          <button type="submit" class="btn btn-primary btn-sm">{{ editId ? 'Actualizar' : 'Crear' }}</button>
+          <button *ngIf="editId" type="button" (click)="cancelar()" class="btn btn-secondary btn-sm ms-2">Cancelar</button>
+        </div>
+      </form>
     </div>
-    <button type="submit" class="btn btn-primary">{{ editId ? 'Actualizar' : 'Crear' }}</button>
-    <button *ngIf="editId" type="button" (click)="cancelar()" class="btn btn-secondary ml-2">Cancelar</button>
-  </form>
+  </div>
 
-  <table class="table table-striped" *ngIf="usuarios.length">
+  <table class="table table-hover table-striped table-bordered" *ngIf="usuarios.length">
     <thead>
       <tr>
         <th>Nombre</th>

--- a/src/app/interceptors/jwt.interceptor.ts
+++ b/src/app/interceptors/jwt.interceptor.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { SesionAdminService } from '../services/session/sesionadmin.service';
+
+@Injectable()
+export class JwtInterceptor implements HttpInterceptor {
+  constructor(private session: SesionAdminService) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.session.getToken();
+    if (token) {
+      const authReq = req.clone({ setHeaders: { token } });
+      return next.handle(authReq);
+    }
+    return next.handle(req);
+  }
+}


### PR DESCRIPTION
## Summary
- provide a new `JwtInterceptor` to attach the token to all HTTP requests
- register the interceptor in the app configuration
- restyle *Usuarios Sistema* form and table to match the project pattern
- add small styling tweaks in its CSS

## Testing
- `npx tsc -p tsconfig.app.json`
- `npm test` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_6859ae7ee50c8321ae9d521324bfc56c