### PR TITLE
Improve usuarios form layout

### DIFF
--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.css
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.css
@@ -6,3 +6,8 @@
 .card form input {
   font-size: 0.875rem;
 }
+
+.card form {
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.html
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.html
@@ -5,34 +5,36 @@
 
   <div class="card mb-4">
     <div class="card-body">
-      <form (ngSubmit)="guardar()" class="row g-3">
-        <div class="col-md-2">
-          <input type="text" class="form-control form-control-sm" name="numero_region" [(ngModel)]="form.numero_region" placeholder="N° Región">
-        </div>
-        <div class="col-md-2">
-          <input type="number" class="form-control form-control-sm" name="inregion" [(ngModel)]="form.inregion" placeholder="Id Región">
-        </div>
-        <div class="col-md-2">
-          <input type="text" class="form-control form-control-sm" name="region" [(ngModel)]="form.region" placeholder="Región">
-        </div>
-        <div class="col-md-3">
-          <input type="text" class="form-control form-control-sm" name="nombre" [(ngModel)]="form.nombre" placeholder="Nombre">
-        </div>
-        <div class="col-md-3">
-          <input type="email" class="form-control form-control-sm" name="correo" [(ngModel)]="form.correo" placeholder="Correo">
-        </div>
-        <div class="col-md-3">
-          <input type="text" class="form-control form-control-sm" name="cargo" [(ngModel)]="form.cargo" placeholder="Cargo">
-        </div>
-        <div class="col-md-3">
-          <input type="text" class="form-control form-control-sm" name="unidad" [(ngModel)]="form.unidad" placeholder="Unidad">
-        </div>
-        <div class="col-md-3">
-          <input type="text" class="form-control form-control-sm" name="rut" [(ngModel)]="form.rut" placeholder="RUT">
-        </div>
-        <div class="col-12 text-end">
-          <button type="submit" class="btn btn-primary btn-sm">{{ editId ? 'Actualizar' : 'Crear' }}</button>
-          <button *ngIf="editId" type="button" (click)="cancelar()" class="btn btn-secondary btn-sm ms-2">Cancelar</button>
+      <form (ngSubmit)="guardar()">
+        <div class="row g-3">
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="numero_region" [(ngModel)]="form.numero_region" placeholder="N° Región" />
+          </div>
+          <div class="col-md-6">
+            <input type="number" class="form-control form-control-sm" name="inregion" [(ngModel)]="form.inregion" placeholder="Id Región" />
+          </div>
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="region" [(ngModel)]="form.region" placeholder="Región" />
+          </div>
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="nombre" [(ngModel)]="form.nombre" placeholder="Nombre" />
+          </div>
+          <div class="col-md-6">
+            <input type="email" class="form-control form-control-sm" name="correo" [(ngModel)]="form.correo" placeholder="Correo" />
+          </div>
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="cargo" [(ngModel)]="form.cargo" placeholder="Cargo" />
+          </div>
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="unidad" [(ngModel)]="form.unidad" placeholder="Unidad" />
+          </div>
+          <div class="col-md-6">
+            <input type="text" class="form-control form-control-sm" name="rut" [(ngModel)]="form.rut" placeholder="RUT" />
+          </div>
+          <div class="col-12 text-end">
+            <button type="submit" class="btn btn-primary btn-sm">{{ editId ? 'Actualizar' : 'Crear' }}</button>
+            <button *ngIf="editId" type="button" (click)="cancelar()" class="btn btn-secondary btn-sm ms-2">Cancelar</button>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- reorganize `usuarios-sistema` form using a two-column layout
- center the form with a max width for better appearance

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6859b31f8e5c83219e3ad17ef7f70163