### PR TITLE
Implement user enable/disable

### DIFF
--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.html
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.html
@@ -66,6 +66,7 @@
         <th>Región</th>
         <th>Cargo</th>
         <th>Unidad</th>
+        <th>Estado</th>
         <th>Acciones</th>
       </tr>
     </thead>
@@ -77,8 +78,16 @@
         <td>{{ u.cargo }}</td>
         <td>{{ u.unidad }}</td>
         <td>
+          <span *ngIf="u.estado; else deshabilitado" class="badge badge-success">Activo</span>
+          <ng-template #deshabilitado>
+            <span class="badge badge-secondary">Inactivo</span>
+          </ng-template>
+        </td>
+        <td>
           <button class="btn btn-sm btn-link" (click)="editar(u)">Editar</button>
-          <button class="btn btn-sm btn-link text-danger" (click)="eliminar(u.id_usersistema)">Eliminar</button>
+          <button class="btn btn-sm btn-link" (click)="cambiarEstado(u)">
+            {{ u.estado ? 'Deshabilitar' : 'Habilitar' }}
+          </button>
         </td>
       </tr>
     </tbody>

--- a/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
+++ b/src/app/components/usuarios-sistema/usuarios-sistema.component.ts
@@ -92,13 +92,13 @@ export class UsuariosSistemaComponent implements OnInit {
     }
   }
 
-  eliminar(id: number): void {
-    if (!confirm('¿Eliminar usuario?')) { return; }
+  cambiarEstado(u: any): void {
     const token = this.session.getToken();
     if (!token) { return; }
-    this.api.eliminarUsuarioSistema(id, token).subscribe({
-      next: () => this.cargarUsuarios(),
-      error: err => console.error('Error eliminando', err)
+    const nuevoEstado = !u.estado;
+    this.api.cambiarEstadoUsuarioSistema(u.id_usersistema, nuevoEstado, token).subscribe({
+      next: () => { u.estado = nuevoEstado; },
+      error: err => console.error('Error cambiando estado', err)
     });
   }
 }

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -288,4 +288,16 @@ export class ApiserviceIndapService {
     return this.http.delete(`${this.apiRoot}/usersistema/${id}`, { headers });
   }
 
+  /** Cambia el estado habilitado/deshabilitado del usuario */
+  cambiarEstadoUsuarioSistema(id: number, estado: boolean, token: string) {
+    const headers = {
+      'Content-Type': 'application/json',
+      token
+    };
+    const body = { estado };
+    return this.http.put<any>(`${this.apiRoot}/usersistema/${id}/estado`, body, {
+      headers
+    });
+  }
+
 }


### PR DESCRIPTION
## Summary
- add API method to change user's enabled state
- toggle user state in admin UI instead of deleting
- show current user state and enable/disable option in table

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6859be26688c8321bacd9c94d89293c2