### PR TITLE
Add endpoint check for certificate download

### DIFF
--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -138,19 +138,15 @@ export class RevisionfichaComponent implements OnInit {
 
     this.mostrarAcciones = !(estadoFicha.includes(buscadoNorm) || halladoEnHist);
 
-    const aprobadoFinanzas =
-      estadoFicha.includes('aprobado - finanzas') ||
-      this.historial.some(h =>
-        this.normalizar(h.estado).includes('aprobado - finanzas')
-      );
-
-    const aprobadoJuridica =
-      estadoFicha.includes('aprobado - juridica') ||
-      this.historial.some(h =>
-        this.normalizar(h.estado).includes('aprobado - juridica')
-      );
-
-    this.puedeDescargar = aprobadoFinanzas && aprobadoJuridica;
+    this.api
+      .fichaAprobadaJuridicaFinanzas(this.idFicha)
+      .subscribe({
+        next : ({ aprobado }) => { this.puedeDescargar = aprobado; },
+        error: err => {
+          console.error('[Revisionficha] Error verificando aprobación', err);
+          this.puedeDescargar = false;
+        }
+      });
 
 
 

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -147,6 +147,12 @@ export class ApiserviceIndapService {
     return this.http.get<any[]>(`${this.baseurl.replace(/\/$/, '')}/observaciondoc/ficha/${idFicha}`);
   }
 
+  /** ¿Ficha aprobada por Jurídica y Finanzas? */
+  fichaAprobadaJuridicaFinanzas(idFicha: number) {
+    const url = `${this.obsRoot}/aprobadosjuridicayfiannzas/${idFicha}`;
+    return this.http.get<{ id_ficha: number; aprobado: boolean }>(url);
+  }
+
   crearObservacionDoc(payload: {
     id_ficha: number;
     id_documento: number;


### PR DESCRIPTION
## Summary
- add a service helper to query `/aprobadosjuridicayfiannzas/{id_ficha}`
- use the backend check in `RevisionfichaComponent` before enabling certificate download

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d0d33e988321b47f38cdddb04f0d