### PR TITLE
Implement final admin approval feature

### DIFF
--- a/src/app/components/revisionficha/revisionficha.component.html
+++ b/src/app/components/revisionficha/revisionficha.component.html
@@ -192,5 +192,21 @@
     </button>
   </div>
 
+  <div *ngIf="esAdmin && puedeDescargar" class="mt-4">
+    <div class="alert alert-warning">
+      <strong>Aprobación final</strong> por parte de nivel central de INDAP.
+      Este es el término del proceso de revisión de la ficha.
+    </div>
+    <div class="mb-3">
+      <label for="obsFinal" class="form-label fw-bold">Observación final</label>
+      <textarea id="obsFinal" class="form-control" rows="3" [(ngModel)]="observacionFinal"></textarea>
+    </div>
+    <div class="d-flex justify-content-end">
+      <button class="btn btn-primary" (click)="finalizarFicha()">
+        Finalizar ficha
+      </button>
+    </div>
+  </div>
+
 
 </div>

--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -46,6 +46,8 @@ export class RevisionfichaComponent implements OnInit {
   mensaje    = '';
   mostrarAcciones = true;
   puedeDescargar = false;
+  esAdmin = false;
+  observacionFinal = '';
   idUsuario!: number;                     // ← ahora será el RUT sin DV
   registro1986Cargado = false;
 
@@ -93,6 +95,8 @@ export class RevisionfichaComponent implements OnInit {
     /*   id_usuario_modificacion  =  RUT sin dígito verificador   */
     const rutSinDv = (userData.rut || '').split('-')[0];  // "16650344-2" -> "16650344"
     this.idUsuario = Number(rutSinDv);
+
+    this.esAdmin = this.session.getUsuarioSistema() === true;
 
     /* 3️⃣  Documentos base */
     this.documentos = (fichaCompleta.documentos || []).map((d: any) => ({
@@ -330,6 +334,24 @@ export class RevisionfichaComponent implements OnInit {
       error: (err) => {
         console.error(err);
         this.msg.show('No se pudo generar el certificado PDF');
+      }
+    });
+  }
+
+  finalizarFicha() {
+    if (!this.idFicha) { return; }
+    this.api.cambiarEstadoFicha(
+      this.idFicha,
+      this.idUsuario,
+      this.observacionFinal || '',
+      'APROBACION FINAL' as any
+    ).subscribe({
+      next: (res) => {
+        this.msg.show(`Ficha finalizada: ${res.estado}`);
+      },
+      error: (err) => {
+        console.error(err);
+        this.msg.show('Error al finalizar la ficha');
       }
     });
   }


### PR DESCRIPTION
## Summary
- add admin-only final approval form
- allow admins to finalize a ficha once all approvals are granted

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685aba51924c83219f028d5ffabcc2ad