### PR TITLE
Implement guard for Certificado tab

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -44,6 +44,7 @@ export const routes: Routes = [
         },
         {
           path: 'certificado',
+          canActivate: [() => import('./guards/ficha-aprobada.guard').then(m => m.fichaAprobadaGuard)],
           loadComponent: () =>
             import('./components/certificado/certificado.component').then(m => m.CertificadoComponent),
         },

--- a/src/app/components/menuadmin/menuadmin.component.html
+++ b/src/app/components/menuadmin/menuadmin.component.html
@@ -4,7 +4,7 @@
     <a [routerLink]="'/ubicacion-contacto'" class="nav-link" routerLinkActive="active">Ubicación/Contacto</a>
     <a [routerLink]="'/directorio'" class="nav-link" routerLinkActive="active">Directorio</a>
     <a [routerLink]="'/revisionficha'" class="nav-link" routerLinkActive="active">Revisión</a>
-    <a [routerLink]="'/certificado'" class="nav-link" routerLinkActive="active">Certificado</a>
+    <a *ngIf="fichaAprobada" [routerLink]="'/certificado'" class="nav-link" routerLinkActive="active">Certificado</a>
   </nav>
   <div class="underline"
        [style.left]="activeTab === 'Datos Empresa' ? '0%' :

--- a/src/app/components/menuadmin/menuadmin.component.ts
+++ b/src/app/components/menuadmin/menuadmin.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { FichaselecionadaService } from '../../services/session/fichaselecionada.service';
 
 @Component({
   selector: 'app-menuadmin',
@@ -9,10 +10,22 @@ import { RouterModule } from '@angular/router';
   templateUrl: './menuadmin.component.html',
   styleUrl: './menuadmin.component.css'
 })
-export class MenuadminComponent {
+export class MenuadminComponent implements OnInit {
   activeTab: string = 'Datos Empresa';
+  fichaAprobada = false;
+
+  private fichaSrv = inject(FichaselecionadaService);
+
+  ngOnInit(): void {
+    const evaluar = (fc: any) => {
+      const estado = fc?.ficha?.estado || '';
+      this.fichaAprobada = estado.trim().toUpperCase() === 'APROBADA';
+    };
+    evaluar(this.fichaSrv.fichaCompletaValue);
+    this.fichaSrv.getFichaCompleta$().subscribe(evaluar);
+  }
 
   setActive(tab: string) {
-    this.activeTab = tab; // Aquí se actualiza correctamente el estado
+    this.activeTab = tab;
   }
 }

--- a/src/app/guards/ficha-aprobada.guard.ts
+++ b/src/app/guards/ficha-aprobada.guard.ts
@@ -1,0 +1,21 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { FichaselecionadaService } from '../services/session/fichaselecionada.service';
+import { MensajeOverlayService } from '../services/serviceui/mensaje-overlay.service';
+
+export const fichaAprobadaGuard: CanActivateFn = () => {
+  const fichaSrv = inject(FichaselecionadaService);
+  const router = inject(Router);
+  const msg = inject(MensajeOverlayService);
+
+  const estado = fichaSrv.fichaCompletaValue?.ficha?.estado;
+  const aprobada = typeof estado === 'string' && estado.trim().toUpperCase() === 'APROBADA';
+
+  if (aprobada) {
+    return true;
+  }
+
+  msg.show('La ficha debe estar APROBADA para acceder al certificado.', 'error');
+  router.navigate(['/revisionficha']);
+  return false;
+};


### PR DESCRIPTION
## Summary
- restrict /certificado route with new `fichaAprobadaGuard`
- only show the Certificado menu option when the ficha is approved
- adjust routing to use the guard

## Testing
- `npm ci`
- `npx ng test --browsers ChromiumHeadless --watch false` *(fails: Chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_685ac60e716c8321b908f8065b6b34fd