### PR TITLE
Fix certificado tab visibility when approved

### DIFF
--- a/src/app/components/menuadmin/menuadmin.component.ts
+++ b/src/app/components/menuadmin/menuadmin.component.ts
@@ -18,9 +18,15 @@ export class MenuadminComponent implements OnInit {
 
   ngOnInit(): void {
     const evaluar = (fc: any) => {
-      const estado = fc?.ficha?.estado || '';
-      this.fichaAprobada = estado.trim().toUpperCase() === 'APROBADA';
+      const estadoActual = (fc?.ficha?.estado || '').trim().toUpperCase();
+      const hist = Array.isArray(fc?.historial) ? fc.historial : [];
+      const aprobadaEnHist = hist.some((h: any) =>
+        (h?.estado || '').trim().toUpperCase() === 'APROBADA'
+      );
+
+      this.fichaAprobada = estadoActual === 'APROBADA' || aprobadaEnHist;
     };
+
     evaluar(this.fichaSrv.fichaCompletaValue);
     this.fichaSrv.getFichaCompleta$().subscribe(evaluar);
   }

--- a/src/app/guards/ficha-aprobada.guard.ts
+++ b/src/app/guards/ficha-aprobada.guard.ts
@@ -8,8 +8,12 @@ export const fichaAprobadaGuard: CanActivateFn = () => {
   const router = inject(Router);
   const msg = inject(MensajeOverlayService);
 
-  const estado = fichaSrv.fichaCompletaValue?.ficha?.estado;
-  const aprobada = typeof estado === 'string' && estado.trim().toUpperCase() === 'APROBADA';
+  const fc = fichaSrv.fichaCompletaValue;
+  const estado = fc?.ficha?.estado;
+  const estadoActual = typeof estado === 'string' && estado.trim().toUpperCase();
+  const hist = Array.isArray(fc?.historial) ? fc.historial : [];
+  const aprobadaHist = hist.some(h => (h?.estado || '').trim().toUpperCase() === 'APROBADA');
+  const aprobada = estadoActual === 'APROBADA' || aprobadaHist;
 
   if (aprobada) {
     return true;


### PR DESCRIPTION
## Summary
- check the history for an `APROBADA` entry when deciding to display the Certificado tab
- update the guard to allow navigation if the history contains `APROBADA`

## Testing
- `npm test -- --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_685ace6581508321b624a30cd68854fd