### PR TITLE
Show admin alert for final revision count

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -11,6 +11,18 @@
     </div>
   </div>
 </div>
+<div *ngIf="esAdmin && aprobadas > 0 && showFinalAlert" class="alert-container">
+  <div class="container">
+    <div class="alert alert-warning text-center m-0 position-relative" role="alert">
+      Hay <span class="text-danger">{{ aprobadas }}</span> fichas aprobadas que requieren revisión final,
+      <a routerLink="/fichasasignadas" class="alert-link">presione aquí</a>
+      para revisarlas.
+      <button type="button" class="close-btn" aria-label="Cerrar" (click)="dismissFinalAlert()">
+        &times;
+      </button>
+    </div>
+  </div>
+</div>
 <router-outlet></router-outlet>
 <!-- <app-fichasasignadas></app-fichasasignadas> -->
 <app-pieadmin></app-pieadmin>

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -3,6 +3,8 @@ import { RouterOutlet, RouterLink, Router, NavigationEnd } from '@angular/router
 import { HeaderadminComponent } from '../../components/headeradmin/headeradmin.component';
 import { PieadminComponent } from '../../components/pieadmin/pieadmin.component';
 import { FichaselecionadaService } from '../../services/session/fichaselecionada.service';
+import { SesionAdminService } from '../../services/session/sesionadmin.service';
+import { ApiserviceIndapService } from '../../services/apis/apiservice-indap.service';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -13,20 +15,39 @@ import { CommonModule } from '@angular/common';
 })
 export class HomeComponent implements OnInit {
   pendientes = 0;
+  aprobadas = 0;
+  esAdmin = false;
   showAlert = true;
+  showFinalAlert = true;
 
-  constructor(private fichaSrv: FichaselecionadaService, private router: Router) {}
+  constructor(
+    private fichaSrv: FichaselecionadaService,
+    private router: Router,
+    private sessionSrv: SesionAdminService,
+    private apiSrv: ApiserviceIndapService,
+  ) {}
 
   ngOnInit(): void {
     this.fichaSrv.getFichasPendientes$().subscribe(n => this.pendientes = n);
+    this.esAdmin = this.sessionSrv.getUsuarioSistema() === true;
+    if (this.esAdmin) {
+      this.apiSrv.totalAprobadasJuridicaFinanzas().subscribe(res => {
+        this.aprobadas = res.total;
+      });
+    }
     this.router.events.subscribe(ev => {
       if (ev instanceof NavigationEnd) {
         this.showAlert = true;
+        this.showFinalAlert = true;
       }
     });
   }
 
   dismissAlert(): void {
     this.showAlert = false;
+  }
+
+  dismissFinalAlert(): void {
+    this.showFinalAlert = false;
   }
 }

--- a/src/app/services/apis/apiservice-indap.service.ts
+++ b/src/app/services/apis/apiservice-indap.service.ts
@@ -153,6 +153,12 @@ export class ApiserviceIndapService {
     return this.http.get<{ id_ficha: number; aprobado: boolean }>(url);
   }
 
+  /** Total de fichas aprobadas por Jurídica y Finanzas */
+  totalAprobadasJuridicaFinanzas() {
+    const url = `${this.obsRoot}/aprobadosjuridicayfiannzas/total`;
+    return this.http.get<{ total: number }>(url);
+  }
+
   crearObservacionDoc(payload: {
     id_ficha: number;
     id_documento: number;

--- a/src/app/services/session/fichaselecionada.service.ts
+++ b/src/app/services/session/fichaselecionada.service.ts
@@ -11,6 +11,7 @@ export class FichaselecionadaService {
   private fichaSeleccionada$ = new BehaviorSubject<any>(null);
   private fichaCompleta$     = new BehaviorSubject<any>(null);
   private fichasPendientes$ = new BehaviorSubject<number>(0);
+  private fichasRevisionFinal$ = new BehaviorSubject<number>(0);
 
   constructor() {
     const selRaw  = localStorage.getItem(this.SELECTED_KEY);
@@ -69,12 +70,25 @@ export class FichaselecionadaService {
     this.fichasPendientes$.next(n);
   }
 
+  /** Número de fichas aprobadas pendientes de revisión final */
+  public setFichasRevisionFinalCount(n: number): void {
+    this.fichasRevisionFinal$.next(n);
+  }
+
   public getFichasPendientes$(): Observable<number> {
     return this.fichasPendientes$.asObservable();
   }
 
+  public getFichasRevisionFinal$(): Observable<number> {
+    return this.fichasRevisionFinal$.asObservable();
+  }
+
   public get fichasPendientesValue(): number {
     return this.fichasPendientes$.value;
+  }
+
+  public get fichasRevisionFinalValue(): number {
+    return this.fichasRevisionFinal$.value;
   }
 
   /** Limpia todos los datos almacenados */
@@ -82,6 +96,7 @@ export class FichaselecionadaService {
     this.fichaSeleccionada$.next(null);
     this.fichaCompleta$.next(null);
     this.fichasPendientes$.next(0);
+    this.fichasRevisionFinal$.next(0);
     localStorage.removeItem(this.SELECTED_KEY);
     localStorage.removeItem(this.COMPLETA_KEY);
   }


### PR DESCRIPTION
## Summary
- add API method for final revision count
- track `fichasRevisionFinal` in session service
- fetch and show approved count alert on home page

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad2140fc88321aaf23bddaab2f45b