### PR TITLE
Add pending approval alert

### DIFF
--- a/src/app/components/revisionficha/revisionficha.component.css
+++ b/src/app/components/revisionficha/revisionficha.component.css
@@ -1,0 +1,16 @@
+/* Alert styles */
+.alert-container .alert {
+  position: relative;
+  padding-right: 2.5rem;
+}
+
+.alert-container .close-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.5rem;
+  background: transparent;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}

--- a/src/app/components/revisionficha/revisionficha.component.html
+++ b/src/app/components/revisionficha/revisionficha.component.html
@@ -126,7 +126,12 @@
   </table>
   <hr>
 
-
+  <div *ngIf="showPendienteAlert" class="alert-container mb-3">
+    <div class="alert alert-danger text-center m-0 position-relative" role="alert">
+      {{ pendienteMsg }}
+      <button type="button" class="close-btn" aria-label="Cerrar" (click)="dismissPendienteAlert()">&times;</button>
+    </div>
+  </div>
 
   <h3 class="mt-4">Historial de la ficha</h3>
 

--- a/src/app/components/revisionficha/revisionficha.component.ts
+++ b/src/app/components/revisionficha/revisionficha.component.ts
@@ -51,6 +51,9 @@ export class RevisionfichaComponent implements OnInit {
   idUsuario!: number;                     // ← ahora será el RUT sin DV
   registro1986Cargado = false;
 
+  showPendienteAlert = false;
+  pendienteMsg = '';
+
   private idFicha!: number;
 
   constructor(
@@ -109,7 +112,20 @@ export class RevisionfichaComponent implements OnInit {
     this.api
       .fichaAprobadaJuridicaFinanzas(this.idFicha)
       .subscribe({
-        next : ({ aprobado }) => { this.puedeDescargar = aprobado; },
+        next : ({ aprobado }) => {
+          this.puedeDescargar = aprobado;
+          if (!aprobado) {
+            const perfil = (this.session.getPerfilActual()?.perfil || '').toLowerCase();
+            if (perfil.includes('finanzas')) {
+              this.pendienteMsg = 'Falta aprobación por Fiscalía';
+            } else {
+              this.pendienteMsg = 'Falta aprobación por Administración y Finanzas';
+            }
+            this.showPendienteAlert = true;
+          } else {
+            this.showPendienteAlert = false;
+          }
+        },
         error: err => {
           console.error('[Revisionficha] Error verificando aprobación', err);
           this.puedeDescargar = false;
@@ -390,6 +406,10 @@ export class RevisionfichaComponent implements OnInit {
         this.msg.show('Error al rechazar la ficha');
       }
     });
+  }
+
+  dismissPendienteAlert() {
+    this.showPendienteAlert = false;
   }
 
 }


### PR DESCRIPTION
## Summary
- show a red alert when the revision is pending approval from another team
- add dismissible alert block above the history table in `Revisionficha`

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_687e47a52a5483218bc040d0f586a099